### PR TITLE
Fix shadow acne on shadow mapping example

### DIFF
--- a/Chapter_14/Shadows/Shadows.c
+++ b/Chapter_14/Shadows/Shadows.c
@@ -186,7 +186,7 @@ int InitShadowMap ( ESContext *esContext )
 
    glGenTextures ( 1, &userData->shadowMapTextureId );
    glBindTexture ( GL_TEXTURE_2D, userData->shadowMapTextureId );
-   glTexParameteri ( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST );
+   glTexParameteri ( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
    glTexParameteri ( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
    glTexParameteri ( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S,     GL_CLAMP_TO_EDGE );
    glTexParameteri ( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T,     GL_CLAMP_TO_EDGE );
@@ -281,7 +281,7 @@ int Init ( ESContext *esContext )
       "   float pixelSize = 0.002; // 1/500                           \n"
       "   vec4 offset = vec4 ( x * pixelSize * v_shadowCoord.w,       \n"
       "                        y * pixelSize * v_shadowCoord.w,       \n"
-      "                        0.0, 0.0 );                            \n"
+      "                        -0.005 * v_shadowCoord.w, 0.0 );       \n"
       "   return textureProj ( s_shadowMap, v_shadowCoord + offset ); \n"
       "}                                                              \n"
       "                                                               \n"


### PR DESCRIPTION
The example "Shadows" in chapter 14 was not working correctly (tested on an iPad Air 1th gen, iOS 9.3.4 and an iPhone 6, iOS 9.3.5). I changed the GL_TEXTURE_MAG_FILTER to GL_LINEAR and I added a bias to the offset used for the textProj() call in the fragments shader of the second pass of rendering. As you can see from the screenshot below, the scene now looks good.
Hope that helps!

![shadow-fix](https://cloud.githubusercontent.com/assets/4048413/18455357/c8ad8efa-7949-11e6-82ce-acd72e6d4995.png)
