### PR TITLE
Make the exit more gracefully on X11

### DIFF
--- a/Common/Source/LinuxX11/esUtil_X11.c
+++ b/Common/Source/LinuxX11/esUtil_X11.c
@@ -29,6 +29,7 @@
 
 // X11 related local variables
 static Display *x_display = NULL;
+static Atom s_wmDeleteMessage;
 
 //////////////////////////////////////////////////////////////////
 //
@@ -79,6 +80,8 @@ EGLBoolean WinCreate(ESContext *esContext, const char *title)
                CopyFromParent, InputOutput,
                CopyFromParent, CWEventMask,
                &swa );
+    s_wmDeleteMessage = XInternAtom(x_display, "WM_DELETE_WINDOW", False);
+    XSetWMProtocols(x_display, win, &s_wmDeleteMessage, 1);
 
     xattr.override_redirect = FALSE;
     XChangeWindowAttributes ( x_display, win, CWOverrideRedirect, &xattr );
@@ -136,6 +139,11 @@ GLboolean userInterrupt(ESContext *esContext)
             {
                 if (esContext->keyFunc != NULL)
                     esContext->keyFunc(esContext, text, 0, 0);
+            }
+        }
+        if (xev.type == ClientMessage) {
+            if (xev.xclient.data.l[0] == s_wmDeleteMessage) {
+                userinterrupt = GL_TRUE;
             }
         }
         if ( xev.type == DestroyNotify )


### PR DESCRIPTION
On my Ubuntu 16.04, when I close a example's window, there will be a error message prompted like below,

> XIO:  fatal IO error 11 (Resource temporarily unavailable) on X server ":0"
> after 10 requests (10 known processed) with 0 events remaining.

I've fixed this problem by refer to this [question](http://stackoverflow.com/questions/10792361/how-do-i-gracefully-exit-an-x11-event-loop).