### PR TITLE
esUtil_win32.c bug may cause windows build crash

### DIFF
--- a/Common/Source/Win32/esUtil_win32.c
+++ b/Common/Source/Win32/esUtil_win32.c
@@ -77,7 +77,9 @@ LRESULT WINAPI ESWindowProc ( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
          }
 
          if ( esContext )
-         ValidateRect ( esContext->eglNativeWindow, NULL );
+         {
+            ValidateRect ( esContext->eglNativeWindow, NULL );
+         }
       }
       break;
 

--- a/Common/Source/Win32/esUtil_win32.c
+++ b/Common/Source/Win32/esUtil_win32.c
@@ -76,7 +76,7 @@ LRESULT WINAPI ESWindowProc ( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
             eglSwapBuffers ( esContext->eglDisplay, esContext->eglSurface );
          }
 
-
+         if ( esContext )
          ValidateRect ( esContext->eglNativeWindow, NULL );
       }
       break;


### PR DESCRIPTION
I found the source esUtil_win32.c line 80 may probably cause crash who cause a nullPtr exception on esContext pointer ，because I build on visual studio 2017, this problem happens almost every time。I think this commit will fix this problem。